### PR TITLE
change default units to check every N mins

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,7 +36,7 @@ const prolific = {
     })
     .then(prolific.parse)
     .catch(error => {
-      prolific.timeout = setTimeout(prolific.check, Number(options.interval) * 1000);
+      prolific.timeout = setTimeout(prolific.check, Number(options.interval) * 1000 * 60);
     });
     
     prolific.checked = new Date().toString();


### PR DESCRIPTION
Thanks for creating this plugin.

In order to keep the site fast for everyone we're now rate limiting requests to /studies. We advise that the page should be checked no more than once per min per user. As a result, the check interval should be in mins rather than seconds.