### PR TITLE
change default units to check every N mins

### DIFF
--- a/background.js
+++ b/background.js
@@ -117,7 +117,7 @@ const prolific = {
       text: prolific.available.length > 0 ? prolific.available.length.toString() : ``
     });
     
-    prolific.timeout = setTimeout(prolific.check, Number(options.interval) * 1000);
+    prolific.timeout = setTimeout(prolific.check, Number(options.interval) * 1000 * 60);
   },
   
   sendStudies () {


### PR DESCRIPTION
Thanks for creating this plugin.

In order to keep the site fast for everyone we're now rate limiting requests to /studies. We advise that the page should be checked no more than once per min per user. As a result, the check interval should be in mins rather than seconds.