### PR TITLE
fix: new Prolific authentication system compatibility

### DIFF
--- a/src/functions/fetchProlificStudies.ts
+++ b/src/functions/fetchProlificStudies.ts
@@ -1,5 +1,8 @@
-export async function fetchProlificStudies() {
-  const response = await fetch('https://www.prolific.co/api/v1/studies/?current=1', { credentials: 'include' });
+export async function fetchProlificStudies(authHeader: any) {
+  const { name, value } = authHeader
+  const headers = { [name]: value }
+  // omit credentials here, since auth is handled via the bearer token
+  const response = await fetch('https://www.prolific.co/api/v1/studies/?current=1', { credentials: 'omit', headers });
   const json: ProlificApiStudies = await response.json();
   return json;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,5 +20,13 @@
     "persistent": true
   },
 
+  "content_scripts": [
+    {
+      "matches": ["https://app.prolific.co/*"],
+      "run_at": "document_end",
+      "js": ["pages/contentScript.js"]
+    }
+  ],
+
   "permissions": ["notifications", "tabs", "webRequest", "webNavigation", "webRequestBlocking", "https://*.prolific.co/*"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,5 +20,5 @@
     "persistent": true
   },
 
-  "permissions": ["notifications", "tabs", "webRequest", "webRequestBlocking", "https://*.prolific.co/*"]
+  "permissions": ["notifications", "tabs", "webRequest", "webNavigation", "webRequestBlocking", "https://*.prolific.co/*"]
 }

--- a/src/pages/background.ts
+++ b/src/pages/background.ts
@@ -1,4 +1,4 @@
-import { browser, Tabs, WebRequest } from 'webextension-scripts/polyfill';
+import { browser, WebRequest } from 'webextension-scripts/polyfill';
 
 import { fetchProlificStudies } from '../functions/fetchProlificStudies';
 import { openProlificStudy } from '../functions/openProlificStudy';
@@ -11,12 +11,12 @@ import { settingsAlertSoundMiddleware } from '../store/settingsAlertSoundMiddlew
 const store = configureStore(prolificStudiesUpdateMiddleware, settingsAlertSoundMiddleware);
 
 let authHeader: WebRequest.HttpHeadersItemType;
-let authTab: Tabs.Tab & { loggedOut?: boolean };
 let timeout = window.setTimeout(main);
 
-async function openAuthTab() {
-  authHeader = null;
-  authTab = await browser.tabs.create({ url: 'https://app.prolific.co/', active: false });
+function updateResults(results: any[]) {
+  store.dispatch(prolificStudiesUpdate(results));
+  store.dispatch(sessionLastChecked());
+  browser.browserAction.setBadgeText({ text: results.length ? results.length.toString() : '' });
 }
 
 async function main() {
@@ -25,21 +25,18 @@ async function main() {
 
   if (authHeader) {
     try {
-      const response = await fetchProlificStudies();
+      const response = await fetchProlificStudies(authHeader);
 
       if (response.results) {
-        store.dispatch(prolificStudiesUpdate(response.results));
-        store.dispatch(sessionLastChecked());
-        browser.browserAction.setBadgeText({ text: response.results.length ? response.results.length.toString() : '' });
+        updateResults(response.results)
         browser.browserAction.setBadgeBackgroundColor({ color: 'red' });
       }
 
       if (response.error) {
         if (response.error.status === 401) {
-          store.dispatch(prolificErrorUpdate(response.error.status));
+          store.dispatch(prolificErrorUpdate(401));
           browser.browserAction.setBadgeText({ text: '!' });
           browser.browserAction.setBadgeBackgroundColor({ color: 'red' });
-          openAuthTab();
         } else {
           store.dispatch(prolificStudiesUpdate([]));
           browser.browserAction.setBadgeText({ text: 'ERR' });
@@ -52,8 +49,9 @@ async function main() {
       browser.browserAction.setBadgeBackgroundColor({ color: 'black' });
       window.console.error('fetchProlificStudies error', error);
     }
-  } else if (!authTab) {
-    openAuthTab();
+  } else {
+    // openAuthTab();
+    store.dispatch(prolificErrorUpdate(401));
   }
 
   timeout = window.setTimeout(main, state.settings.check_interval * 1000);
@@ -64,33 +62,48 @@ browser.notifications.onClicked.addListener((notificationId) => {
   openProlificStudy(notificationId);
 });
 
-browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (authTab && authTab.id == tabId && !authTab.loggedOut) {
-    if (changeInfo.status == 'complete') {
-      if (tab.url === 'https://app.prolific.co/login') {
-        authTab.loggedOut = true;
-        browser.tabs.highlight({ windowId: tab.windowId, tabs: tab.index });
-      }
-    }
-  }
-});
+function handleSignedOut() {
+  authHeader = null
+  updateResults([])
+  store.dispatch(prolificErrorUpdate(401))
+}
+
+// Watch for url changes and handle sign out
+browser.webNavigation.onCompleted.addListener(
+  (details) => {
+    handleSignedOut();
+  },
+  {
+    url: [{ urlEquals: 'https://www.prolific.co/auth/accounts/login/'}],
+  },
+);
+
+// Prolific is a single page app, so we need to watch
+// the history state for changes too
+browser.webNavigation.onHistoryStateUpdated.addListener(
+  (details) => {
+    handleSignedOut();
+  },
+  {
+    url: [{ urlEquals: 'https://app.prolific.co/login'}],
+  },
+);
 
 // Parse and save the Authorization header from any Prolific request.
 browser.webRequest.onBeforeSendHeaders.addListener(
   (details) => {
     const foundAuthHeader = details.requestHeaders.find((header) => header.name === 'Authorization');
 
+
     if (foundAuthHeader) {
+      if (foundAuthHeader.value === 'Bearer null') {
+        return
+      }
+
       let restart = false;
 
       if (!authHeader) {
         restart = true;
-      }
-
-      if (authTab && authTab.id === details.tabId && !authTab.loggedOut) {
-        restart = true;
-        authTab = null;
-        browser.tabs.remove(details.tabId);
       }
 
       authHeader = foundAuthHeader;
@@ -103,24 +116,7 @@ browser.webRequest.onBeforeSendHeaders.addListener(
     return {};
   },
   {
-    urls: ['https://*.prolific.co/*'],
-  },
-  ['blocking', 'requestHeaders'],
-);
-
-// Add the auth header to any reqeuest from the background to the studies API.
-browser.webRequest.onBeforeSendHeaders.addListener(
-  (details) => {
-    if (authHeader && details.tabId === -1 && details.method === 'GET') {
-      return {
-        requestHeaders: [...details.requestHeaders, authHeader],
-      };
-    }
-
-    return {};
-  },
-  {
-    urls: ['https://www.prolific.co/api/v1/studies/*'],
+    urls: ['https://www.prolific.co/api/*'],
   },
   ['blocking', 'requestHeaders'],
 );

--- a/src/pages/background.ts
+++ b/src/pages/background.ts
@@ -50,7 +50,6 @@ async function main() {
       window.console.error('fetchProlificStudies error', error);
     }
   } else {
-    // openAuthTab();
     store.dispatch(prolificErrorUpdate(401));
   }
 

--- a/src/pages/contentScript.js
+++ b/src/pages/contentScript.js
@@ -1,0 +1,7 @@
+// adds class to app body when PA is enabled
+(function () {
+  var app = document.getElementById('app');
+  if (app) {
+    app.classList.add('pa-enabled');
+  }
+})();


### PR DESCRIPTION
Hi @Kadauchi,

Thanks for accepting PRs.

To get Prolific Assistant working with Prolific's new authentication method, I had to change a few things relating to how auth is handled here. 

Firstly, the auth tab does not automatically open/close any more as this was causing some problems with logging out intermittently. 

Secondly, it should now detect logouts of the app correctly using the `onHistoryStateUpdated` api -as such, the session in PA should align with the session in the app.

I have also added a small content script which adds a class to the app, such that we can detect PA usage and handle differently, or send a message to PA users etc in the future should we need to.

I am not too well versed in Typescript so please do make any required changes there if needed.

Hopefully it all makes sense. Let me know if you have any questions on this, or if you need any test accounts or further assistance.

Cheers,
Andrew